### PR TITLE
Prevent a nasty lockup when bad proxy data is sent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ ebin/
 *.plt
 erl_crash.dump
 logs/
+.rebar
+*.swp

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ a third tuple containing proxy protocol information:
 Sure why don't you
 
 ``` bash
-$ rebar get-deps -C rebar.config.test
+$ rebar get-deps compile -C rebar.config.test
 $ rebar compile ct skip_deps=true -C rebar.config.test
 ```
 

--- a/src/ranch_proxy.erl
+++ b/src/ranch_proxy.erl
@@ -271,7 +271,10 @@ reset_socket_opts(ProxySocket, Opts) ->
     setopts(ProxySocket, Opts2).
 
 get_next_timeout(_, _, infinity) ->
-    infinity;
+    %% Never leave `infinity' in place. This may be valid for socket
+    %% accepts, but is fairly dangrous and risks causing lockups when
+    %% the data over the socket is bad or invalid.
+    ?DEFAULT_PROXY_TIMEOUT;
 get_next_timeout(T1, T2, Timeout) ->
     TimeUsed = round(timer:now_diff(T2, T1) / 1000),
     erlang:max(?DEFAULT_PROXY_TIMEOUT, Timeout - TimeUsed).
@@ -304,5 +307,5 @@ dest_from_socket(Transport, Socket) ->
 bearer_port(#proxy_socket{csocket = Port}) -> Port.
 
 config(Key) ->
-    {ok, Val} = application:get_env(Key),
+    {ok, Val} = application:get_env(ranch_proxy_protocol, Key),
     Val.

--- a/src/ranch_proxy_protocol.app.src
+++ b/src/ranch_proxy_protocol.app.src
@@ -8,5 +8,5 @@
                   stdlib,
                   ranch
                  ]},
-  {env, [{proxy_protocol_timeout, 100}]}
+  {env, [{proxy_protocol_timeout, 55000}]} % Never put 'infinity'
  ]}.


### PR DESCRIPTION
When bad/incomplete data is sent to the proxy protocol, ranch's
'infinity' timeout may cause the parser (with {packet, line}) to never
return. This in turn locks up the server and brings it down without ever
crashing it.

This fix makes it so that a configured timeout (now made much larger)
can be substituted in to replace the 'infinity' value whenever it is
submitted, working around the issue.
