### PR TITLE
Fix connection leak

### DIFF
--- a/src/ranch_proxy.erl
+++ b/src/ranch_proxy.erl
@@ -89,11 +89,14 @@ accept(#proxy_socket{lsocket = LSocket,
                             reset_socket_opts(ProxySocket, Opts),
                             {ok, ProxySocket};
                         not_proxy_protocol ->
+                            close(ProxySocket),
                             {error, not_proxy_protocol}
                     end;
                 Other ->
+                    close(ProxySocket),
                     {error, Other}
             after NextWait ->
+                    close(ProxySocket),
                     {error, {timeout, proxy_handshake}}
             end;
         {error, Error} ->

--- a/src/ranch_proxy_protocol.app.src
+++ b/src/ranch_proxy_protocol.app.src
@@ -1,7 +1,7 @@
 {application, ranch_proxy_protocol,
  [
   {description, "Ranch Proxy Protocol Transport"},
-  {vsn, "1.0.1"},
+  {vsn, "1.0.2"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
When the data is no longer good after an accept, not closing the
connection leads to leaks.
