### PR TITLE
Add proper support for match_port/1 to ssl proxy

### DIFF
--- a/src/ranch_proxy_protocol.erl
+++ b/src/ranch_proxy_protocol.erl
@@ -216,7 +216,7 @@ listen_port(_, #proxy_socket{lsocket = Port}) ->
     Port.
 
 -spec match_port(transport(), proxy_socket()) -> port().
-match_port(_, #proxy_socket{csocket = Port}) -> Port.
+match_port(Transport, Socket) -> bearer_port(Transport, Socket).
 
 %% Internal
 create_proxy_protocol_header(SourceAddress, DestAddress, SourcePort, DestPort)

--- a/src/ranch_proxy_protocol.erl
+++ b/src/ranch_proxy_protocol.erl
@@ -216,7 +216,7 @@ listen_port(_, #proxy_socket{lsocket = Port}) ->
     Port.
 
 -spec match_port(transport(), proxy_socket()) -> port().
-match_port(_, #proxy_socket{csocket=Port}) when is_port(Port) -> Port.
+match_port(_, #proxy_socket{csocket = Port}) -> Port.
 
 %% Internal
 create_proxy_protocol_header(SourceAddress, DestAddress, SourcePort, DestPort)

--- a/src/ranch_proxy_ssl.erl
+++ b/src/ranch_proxy_ssl.erl
@@ -28,7 +28,8 @@
          close/1,
          opts_from_socket/2,
          bearer_port/1,
-         listen_port/1
+         listen_port/1,
+         match_port/1
         ]).
 
 -type proxy_opts() :: ranch_proxy_protocol:proxy_opts().
@@ -180,6 +181,9 @@ bearer_port(#ssl_socket{proxy_socket=ProxySocket}) ->
 -spec listen_port(ssl_socket()) -> port().
 listen_port(#ssl_socket{proxy_socket=ProxySocket}) ->
     ranch_proxy_protocol:listen_port(?TRANSPORT, ProxySocket).
+
+match_port(#ssl_socket{proxy_socket=ProxySocket}) ->
+    ranch_proxy_protocol:match_port(?TRANSPORT, ProxySocket).
 
 -spec opts_from_socket(atom(), ssl_socket()) ->
                               ranch_proxy_protocol:proxy_opts().


### PR DESCRIPTION
- Relax the constraints on the underlying match_port implementation; it
  was valid for a TCP-only mechanism for the underlying socket, but when
  it's SSL, it has to return what makes sense to return.
- Extend ranch_proxy_ssl to use it.

Arguably we should eventually just switch to 'bearer_port' for these, I
guess. Would it make more sense to go that way, @omarkj ? That would however prompt for backwards incompatibilities.