### PR TITLE
Workaround for ssl:recv(_,_,0) bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ a third tuple containing proxy protocol information:
                                 {dest_address, inet:ip_address()} |
                                 {source_port, inet:port_number()} |
                                 {dest_port, inet:port_number()}].
--spec proxyname(proxy_socket()) -> 
+-spec proxyname(proxy_socket()) ->
                        {ok, proxy_protocol_info()} | {error, atom()}.
 ```
 
@@ -45,8 +45,7 @@ a third tuple containing proxy protocol information:
 Sure why don't you
 
 ``` bash
-$ rebar get-deps compile -C rebar.config.test
-$ rebar compile ct skip_deps=true -C rebar.config.test
+$ rebar3 ct
 ```
 
 # License

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 %% -*- erlang -*-
 {erl_opts, [debug_info,
-            warnings_as_errors
+            warnings_as_errors,
+            {platform_define, "^(19|2)", ssl_recv_zero}
            ]}.
 
 {deps,


### PR DESCRIPTION
OTP =< 18.3.3 can't handle a zero timeout in a majority of the ssl
module's functions. For that special case, we're using a timeout of 1
instead, which is way better than throwing an error that ranch swallows,
and all you see is `function_clause` and then you spend 4 hours
searching for it, only to find the issue deep in OTP.