### PR TITLE
Add sni_hostname to v1 proxy socket's conn info

### DIFF
--- a/src/ranch_proxy_protocol.erl
+++ b/src/ranch_proxy_protocol.erl
@@ -63,7 +63,33 @@ get_csocket(#proxy_socket{csocket = CSocket}) ->
 
 -spec set_csocket(proxy_socket(), port()|ssl:sslsocket()) -> proxy_socket().
 set_csocket(ProxySocket, NewCSocket) ->
-    ProxySocket#proxy_socket{csocket = NewCSocket}.
+    ProxySocket#proxy_socket{
+      csocket = NewCSocket,
+      connection_info=maybe_add_sni_hostname(NewCSocket,
+                                             ProxySocket#proxy_socket.connection_info)
+     }.
+
+-spec maybe_add_sni_hostname(port()|ssl:sslsocket(), list()) -> list().
+maybe_add_sni_hostname(CSocket, ConnectionInfo)
+  when is_port(CSocket) ->
+    ConnectionInfo;
+maybe_add_sni_hostname(CSocket, ConnectionInfo) ->
+    case {
+      proplists:is_defined(sni_hostname, ConnectionInfo),
+      ssl:connection_information(CSocket, [sni_hostname]) } of
+        {true, _} ->
+            ConnectionInfo;
+        {false, {ok, []}} ->
+            ConnectionInfo;
+        {false, {ok, [{sni_hostname, Hostname}]}} ->
+            BinaryHostname  =
+                case is_binary(Hostname) of
+                    true -> Hostname;
+                    false -> list_to_binary(Hostname)
+                end,
+            [{sni_hostname, BinaryHostname}|ConnectionInfo]
+    end.
+
 
 -spec listen(transport(), opts()) -> {ok, proxy_socket()} | {error, atom()}.
 listen(Transport, Opts) ->


### PR DESCRIPTION
If #proxy_socket.connection_info does not have an `sni_hostname` set,
but the underlying sslsocket does, we'll use it