### PR TITLE
Allow SSL opts to be configured live for accept

### DIFF
--- a/src/ranch_proxy_protocol.app.src
+++ b/src/ranch_proxy_protocol.app.src
@@ -8,5 +8,6 @@
                   stdlib,
                   ranch
                  ]},
-  {env, [{proxy_protocol_timeout, 55000}]} % Never put 'infinity'
+  {env, [{proxy_protocol_timeout, 55000}, % Never put 'infinity'
+         {ssl_accept_opts, []}]}
  ]}.

--- a/src/ranch_proxy_protocol.erl
+++ b/src/ranch_proxy_protocol.erl
@@ -99,9 +99,13 @@ maybe_add_proxy_v2_info(CSocket, ConnectionInfo) ->
 ensure_binary_sni_hostname([{sni_hostname, Hostname}|Props])
   when is_binary(Hostname) ->
     [{sni_hostname, Hostname}|ensure_binary_sni_hostname(Props)];
-ensure_binary_sni_hostname([{sni_hostname, Hostname}|Props]) ->
+ensure_binary_sni_hostname([{sni_hostname, Hostname}|Props])
+  when is_list(Hostname) ->
     [{sni_hostname, list_to_binary(Hostname)}
      |ensure_binary_sni_hostname(Props)];
+ensure_binary_sni_hostname([{sni_hostname, undefined}|Props]) ->
+    %% Call was made without SNI
+    ensure_binary_sni_hostname(Props);
 ensure_binary_sni_hostname([Head|Props]) ->
     [Head|ensure_binary_sni_hostname(Props)];
 ensure_binary_sni_hostname([]) -> [].

--- a/src/ranch_proxy_ssl.erl
+++ b/src/ranch_proxy_ssl.erl
@@ -75,7 +75,8 @@ accept(#ssl_socket{proxy_socket = ProxySocket,
     case ranch_proxy:accept(ProxySocket, Timeout) of
         {ok, ProxySocket1} ->
             CSocket = ranch_proxy_protocol:get_csocket(ProxySocket1),
-            case ssl:ssl_accept(CSocket, Opts, Timeout) of
+            SSLOpts = application:get_env(ranch_proxy_protocol, ssl_accept_opts, []),
+            case ssl:ssl_accept(CSocket, SSLOpts++Opts, Timeout) of
                 {ok, SslSocket} ->
                     ProxySocket2 = ranch_proxy_protocol:set_csocket(ProxySocket1,
                                                                     SslSocket),


### PR DESCRIPTION
Allows to do changes such as modifying certificates at run time without
restarting the SSL server.

WIP would need tests