### PR TITLE
Add get_csocket to ranch_proxy_ssl

### DIFF
--- a/src/ranch_proxy_ssl.erl
+++ b/src/ranch_proxy_ssl.erl
@@ -36,6 +36,9 @@
          ssl_connection_information/2
         ]).
 
+% Record manipulation
+-export([get_csocket/1]).
+
 -type proxy_opts() :: ranch_proxy_protocol:proxy_opts().
 -type proxy_socket() :: ranch_proxy_protocol:proxy_socket().
 -type proxy_protocol_info() :: ranch_proxy_protocol:proxy_protocol_info().
@@ -44,6 +47,11 @@
 -define(TRANSPORT, ranch_ssl).
 
 -export_type([ssl_socket/0]).
+
+%% Record manipulation API
+-spec get_csocket(ssl_socket()) -> port().
+get_csocket(#ssl_socket{proxy_socket=ProxySocket}) ->
+    ranch_proxy_protocol:get_csocket(ProxySocket).
 
 -spec name() -> atom().
 name() -> proxy_protocol_ssl.


### PR DESCRIPTION
Allows to get the socket without depending on the underlying record structure.