### PR TITLE
Prepare for hex.pm

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,8 +6,7 @@
 
 {deps,
  [
-  {ranch, [], {git, "https://github.com/ninenines/ranch.git",
-               {tag, "1.3.2"}}}]}.
+  {ranch, "1.3.2"}]}.
 
 {profiles, [
             {test, [{deps,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,6 @@
-[{<<"ranch">>,
-  {git,"https://github.com/ninenines/ranch.git",
-       {ref,"a004ad710eddd0c21aaccc30d5633a76b06164b5"}},
-  0}].
+{"1.1.0",
+[{<<"ranch">>,{pkg,<<"ranch">>,<<"1.3.2">>},0}]}.
+[
+{pkg_hash,[
+ {<<"ranch">>, <<"E4965A144DC9FBE70E5C077C65E73C57165416A901BD02EA899CFD95AA890986">>}]}
+].

--- a/src/ranch_proxy_protocol.app.src
+++ b/src/ranch_proxy_protocol.app.src
@@ -9,5 +9,6 @@
                   ranch
                  ]},
   {env, [{proxy_protocol_timeout, 55000}, % Never put 'infinity'
-         {ssl_accept_opts, []}]}
+         {ssl_accept_opts, []}]},
+  {licenses, ["BSD 3-Clause"]}
  ]}.


### PR DESCRIPTION
With those two changes, I was able to publish `ranch_proxy_protocol` to Hex.pm.

References #29.