### PR TITLE
Fix ssl:ssl_accept deprecation and export_all warn

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,11 @@
                        {git, "https://github.com/extend/ct_helper.git",
                         {branch, "master"}}}
                      ]
+                    },
+                    {erl_opts,
+                     [
+                      nowarn_export_all
+                     ]
                     }]
             }
            ]

--- a/src/ranch_proxy_ssl.erl
+++ b/src/ranch_proxy_ssl.erl
@@ -87,7 +87,7 @@ accept(#ssl_socket{proxy_socket = ProxySocket,
         {ok, ProxySocket1} ->
             CSocket = ranch_proxy_protocol:get_csocket(ProxySocket1),
             SSLOpts = application:get_env(ranch_proxy_protocol, ssl_accept_opts, []),
-            case ssl:ssl_accept(CSocket, SSLOpts++Opts, Timeout) of
+            case ssl:handshake(CSocket, SSLOpts++Opts, Timeout) of
                 {ok, SslSocket} ->
                     ProxySocket2 = ranch_proxy_protocol:set_csocket(ProxySocket1,
                                                                     SslSocket),


### PR DESCRIPTION
- Erlang/OTP 20 introduces a warning when `export_all` is used; (http://www.erlang.org/news/114)
- Erlang/OTP 21 deprecates `ssl:ssl_accept` in favor of `ssl:handshake`. (http://erlang.org/doc/man/ssl.html#ssl_accept-3)

These updates generate warnings when compiling this project with rebar3, that fails by the `warnings_as_errors` option on rebar.config.

This PR fix it using `ssl:handshake` over `ssl:ssl_accept` and setting the `nowarn_export_all` option on rebar.config test profile.