### PR TITLE
Add link to repo to .app.src

### DIFF
--- a/src/ranch_proxy_protocol.app.src
+++ b/src/ranch_proxy_protocol.app.src
@@ -10,5 +10,6 @@
                  ]},
   {env, [{proxy_protocol_timeout, 55000}, % Never put 'infinity'
          {ssl_accept_opts, []}]},
+  {links,[{"Github","https://github.com/heroku/ranch_proxy_protocol"}]},
   {licenses, ["BSD 3-Clause"]}
  ]}.


### PR DESCRIPTION
Also, could you cut & publish a new release to hex.pm with at least https://github.com/heroku/ranch_proxy_protocol/commit/4e0f73a385f37cc6f277363695e91f4fc7a81f24? 
That would make it way easier to upgrade & use rabbit_common/amqp_client/amqp on OTP21.
Thanks!