### PR TITLE
Add missing documented TLV types

### DIFF
--- a/src/ranch_proxy.hrl
+++ b/src/ranch_proxy.hrl
@@ -16,9 +16,14 @@
 %% TLV types for additional headers
 -define(PP2_TYPE_ALPN, 16#01).
 -define(PP2_TYPE_AUTHORITY, 16#02).
+-define(PP2_TYPE_CRC32C, 16#03).
+-define(PP2_TYPE_NOOP, 16#04).
 -define(PP2_TYPE_SSL, 16#20).
 -define(PP2_SUBTYPE_SSL_VERSION, 16#21).
 -define(PP2_SUBTYPE_SSL_CN, 16#22).
+-define(PP2_SUBTYPE_SSL_CIPHER, 16#23).
+-define(PP2_SUBTYPE_SSL_SIG_ALG, 16#24).
+-define(PP2_SUBTYPE_SSL_KEY_ALG, 16#25).
 -define(PP2_TYPE_NETNS, 16#30).
 
 %% SSL Client fields

--- a/src/ranch_proxy_protocol.erl
+++ b/src/ranch_proxy_protocol.erl
@@ -413,12 +413,22 @@ pp2_type(?PP2_TYPE_ALPN) ->
     negotiated_protocol;
 pp2_type(?PP2_TYPE_AUTHORITY) ->
     authority;
+pp2_type(?PP2_TYPE_CRC32C) ->
+    crc32c;
+pp2_type(?PP2_TYPE_NOOP) ->
+    noop;
 pp2_type(?PP2_TYPE_SSL) ->
     ssl;
 pp2_type(?PP2_SUBTYPE_SSL_VERSION) ->
     protocol;
 pp2_type(?PP2_SUBTYPE_SSL_CN) ->
     sni_hostname;
+pp2_type(?PP2_SUBTYPE_SSL_CIPHER) ->
+    ssl_cipher;
+pp2_type(?PP2_SUBTYPE_SSL_SIG_ALG) ->
+    ssl_sig_alg;
+pp2_type(?PP2_SUBTYPE_SSL_KEY_ALG) ->
+    ssl_key_alg;
 pp2_type(?PP2_TYPE_NETNS) ->
     netns;
 pp2_type(_) ->


### PR DESCRIPTION
According to http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt, the following TLV types are registered:
```
PP2_TYPE_ALPN           0x01
PP2_TYPE_AUTHORITY      0x02
PP2_TYPE_CRC32C         0x03
PP2_TYPE_NOOP           0x04
PP2_TYPE_SSL            0x20
PP2_SUBTYPE_SSL_VERSION 0x21
PP2_SUBTYPE_SSL_CN      0x22
PP2_SUBTYPE_SSL_CIPHER  0x23
PP2_SUBTYPE_SSL_SIG_ALG 0x24
PP2_SUBTYPE_SSL_KEY_ALG 0x25
PP2_TYPE_NETNS          0x30
```

Comparing those to the ones mentioned in ranch_proxy.hrl, we find the following ones to be missing:
```
PP2_TYPE_CRC32C         0x03
PP2_TYPE_NOOP           0x04
PP2_SUBTYPE_SSL_CIPHER  0x23
PP2_SUBTYPE_SSL_SIG_ALG 0x24
PP2_SUBTYPE_SSL_KEY_ALG 0x25
```

This PR adds the missing values to the _parser_. 

**Rationale**: we were observing return values (for `#proxy_socket.connection_info`) like `[{invalid_pp2_type, _}, {invalid_pp2_type, _}]` in calls to `ranch_proxy_protocol:pp2_type/1`, with no real consequence except misleading us into thinking _there might be an error here_.

It seems the TLV types are collected for information purposes only, so this change is basically inocuous.